### PR TITLE
Fix large hero and teaser images

### DIFF
--- a/_publications/2025-05-01-wandering-spirit-mixed-reality-gameplay.md
+++ b/_publications/2025-05-01-wandering-spirit-mixed-reality-gameplay.md
@@ -8,6 +8,7 @@ date: 2025-05-01
 venue: 'CHI EA 2025 Student Game Competition'
 paperurl: 'https://dl.acm.org/doi/10.1145/3706599.3720314'
 citation: 'WenFan Wang, et al. (2025). "Wandering Spirit: Exploring Cooperative Mixed-Reality Gameplay with Shared Physical Props." <i>CHI EA 2025 Student Game Competition</i>.'
+header:
+  image: 500x300.png
+  teaser: 500x300.png
 ---
-
-\

--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -69,8 +69,11 @@
 .archive__item-teaser {
   border-radius: $border-radius;
   overflow: hidden;
+  max-width: 250px;
+  margin-right: 1rem;
   img {
     width: 100%;
+    height: auto;
   }
 }
 

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -163,6 +163,10 @@
 .page__hero-image {
   width: 100%;
   height: auto;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
   -ms-interpolation-mode: bicubic;
 }
 

--- a/_selected_publication/2025-05-01-wandering-spirit-mixed-reality-gameplay.md
+++ b/_selected_publication/2025-05-01-wandering-spirit-mixed-reality-gameplay.md
@@ -8,6 +8,7 @@ date: 2025-05-01
 venue: 'CHI EA 2025 Student Game Competition'
 paperurl: 'https://dl.acm.org/doi/10.1145/3706599.3720314'
 citation: 'WenFan Wang, et al. (2025). "Wandering Spirit: Exploring Cooperative Mixed-Reality Gameplay with Shared Physical Props." <i>CHI EA 2025 Student Game Competition</i>.'
+header:
+  image: 500x300.png
+  teaser: 500x300.png
 ---
-
-\

--- a/_selected_publication/2025-05-02-aideation-human-ai-collaborative-ideation-system.md
+++ b/_selected_publication/2025-05-02-aideation-human-ai-collaborative-ideation-system.md
@@ -8,6 +8,7 @@ date: 2025-05-01
 venue: 'CHI 2025'
 paperurl: 'https://dl.acm.org/doi/10.1145/3706598.3714148'
 citation: 'WenFan Wang, et al. (2025). "AIdeation: Designing a Human-AI Collaborative Ideation System for Concept Designers." <i>CHI 2025</i>.'
+header:
+  image: CHI25_AIdeation.png
+  teaser: CHI25_AIdeation.png
 ---
-
-\


### PR DESCRIPTION
## Summary
- constrain hero image width so header pictures don't dominate the page
- limit teaser image width on archives for better thumbnails

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683be7cc72cc8323b254179c69c9c013